### PR TITLE
from __future__ import print_function

### DIFF
--- a/log.py
+++ b/log.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from string import Template
 from . import settings as conf
 from . import defaults


### PR DESCRIPTION
Line 41 has __print('SublimeBump: ', end='')__ and the __end__ parameter is a Syntax Error in Python 2 without this `__future__`import.

$ __python2 -c "print('Hello', end='')"__  # Syntax Error